### PR TITLE
use snap builds on Ubuntu 18.04

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,8 +28,9 @@ fn bindgen(target: &str) {
         },
         "x86_64-unknown-linux-gnu" => {
             builder = builder
-                .clang_arg("-I/app/include/octave-5.1.0")
-                .clang_arg("-I/usr/lib/gcc/x86_64-unknown-linux-gnu/8.3.0/include");
+                .clang_arg("-I/app/include/octave-5.1.0") // flatpak
+                .clang_arg("-I/usr/lib/gcc/x86_64-unknown-linux-gnu/8.3.0/include") // flatpak
+                .clang_arg("-I/snap/octave/5/usr/include/octave-5.1.0");
         },
         _ => (),
     }
@@ -57,7 +58,8 @@ fn main() {
             build.include(r"C:\Octave\Octave-5.1.0.0\mingw64\include\octave-5.1.0");
         },
         "x86_64-unknown-linux-gnu" => {
-            build.include("/app/include/octave-5.1.0");
+            build.include("/app/include/octave-5.1.0"); // flatpak
+            build.include("/snap/octave/5/usr/include/octave-5.1.0");
         },
         _ => (),
     }
@@ -75,6 +77,7 @@ fn main() {
             println!("cargo:rustc-link-lib=octinterp-7");
         },
         "x86_64-unknown-linux-gnu" => {
+            println!("cargo:rustc-link-search=/snap/octave/5/usr/lib/x86_64-linux-gnu");
             println!("cargo:rustc-link-lib=octave");
             println!("cargo:rustc-link-lib=octinterp");
         },

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,8 @@
 # Octave and Rust must both be installed.
 # flatpak run --command=sh --devel org.octave.Octave
 
-export PATH=/usr/lib/sdk/rust-stable/bin/:$PATH
+# flatpak
+# export PATH=/usr/lib/sdk/rust-stable/bin/:$PATH
+export PATH=/snap/octave/5/usr/bin:$PATH
 # cargo clean
 cargo build --target x86_64-unknown-linux-gnu --release


### PR DESCRIPTION
Hot off the press, Octave now supports snaps.
https://snapcraft.io/octave

Octave turns to snaps to reduce dependency on Linux distribution maintainers
https://snapcraft.io/blog/octave-turns-to-snaps-to-reduce-dependency-on-linux-distribution-maintainers

I found the snap way easier to install and use than the flatpak.
https://flathub.org/apps/details/org.octave.Octave

After updating my Ubuntu VM from 16.04 to 18.04, I was able to use the files distributed with the snap to build this project. The Octave snap has a base of `core18` which is based on Ubuntu 18.04. https://snapcraft.io/core18 . On Ubuntu 16.04, I got library errors for running the bundled `ld` and couldn't figure out a good work-a-round.

Being able to use a snap from an Ubuntu 18.04 image, but be a good build option.