### PR TITLE
don't link with Octave libs on GNU/Linux

### DIFF
--- a/example-helloworld/build.rs
+++ b/example-helloworld/build.rs
@@ -1,7 +1,22 @@
+use std::env;
+
 fn main() {
-    if let Ok(lib) = std::env::var("OCTAVE_LIB") {
+    let target = &env::var("TARGET").unwrap();
+
+    if let Ok(lib) = env::var("OCTAVE_LIB") {
         println!("cargo:rustc-link-search={}", lib);
     }
-    println!("cargo:rustc-link-lib=octave");
-    println!("cargo:rustc-link-lib=octinterp");
+    match target.as_str() {
+        "x86_64-pc-windows-gnu" => {
+            println!("cargo:rustc-link-lib=octave-7");
+            println!("cargo:rustc-link-lib=octinterp-7");
+        },
+        "x86_64-unknown-linux-gnu" => {
+        },
+        "x86_64-apple-darwin" => {
+            println!("cargo:rustc-link-lib=octave");
+            println!("cargo:rustc-link-lib=octinterp");
+        },
+        _ => (),
+    }
 }

--- a/octh/build.rs
+++ b/octh/build.rs
@@ -98,8 +98,6 @@ fn main() {
             println!("cargo:rustc-link-lib=octinterp-7");
         },
         "x86_64-unknown-linux-gnu" => {
-            println!("cargo:rustc-link-lib=octave");
-            println!("cargo:rustc-link-lib=octinterp");
         },
         "x86_64-apple-darwin" => {
             // brew install llvm octave


### PR DESCRIPTION
Drop `rustc-link-lib` options on `x86_64-unknown-linux-gnu`. Duplicate target-dependent link logic into helloworld.

Closes #55.